### PR TITLE
Fix windows autoinstall and run

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "markdown-oxide"
 name = "Markdown Oxide"
 description = "Obsidian-Inspired PKM Language Server for Zed"
-version = "0.0.4"
+version = "0.0.5"
 schema_version = 1
 authors = ["Felix Zeller <felixazeller@gmail.com>"]
 repository = "https://github.com/Feel-ix-343/markdown-oxide"


### PR DESCRIPTION
Greetings! 

```
let asset_name_no_extension = asset_name.replace(".tar.gz", "");
```
This line broke automatic setup on windows since windows assets are not tgz.
Also i've added executable extension (official ruff plugin [does](https://github.com/zed-industries/zed/blob/044eb7b99048e79da5aa3f2dd489ff3ed8f97a32/extensions/ruff/src/ruff.rs#L93) something similar).

It __shouldn't__ break anything, but please check on mac/linux if you have one :)